### PR TITLE
Fix RMagick deprecation notice, lowercase "rmagick" now required

### DIFF
--- a/lib/photofy.rb
+++ b/lib/photofy.rb
@@ -2,7 +2,7 @@ require 'photofy/dummy_s3methods'
 require 'photofy/core'
 require 'tempfile'
 begin
-  require "RMagick"
+  require "rmagick"
 rescue Exception => e
   puts "Unable to load 'RMagick' for any image manipulations methods"
 end


### PR DESCRIPTION
This fixes the following notice when using newer versions of rmagick > 2.15.2 (currently rmagick is at 2.15.4):

`[DEPRECATION] requiring "RMagick" is deprecated. Use "rmagick" instead`
